### PR TITLE
update rake-compiler-dock docker images to 1.7.1

### DIFF
--- a/third_party/rake-compiler-dock/rake_aarch64-linux.current_version
+++ b/third_party/rake-compiler-dock/rake_aarch64-linux.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux:cf4b55556a01ddcaef74399ba3f3371efbb01921@sha256:cff514568925140423831235a0248c97cc96c9aa2e8d4363691ca78943b03582
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux:e5755f6c413b7e99a63fe1d7cfc26b136fe8b3ba@sha256:6386d6af4126662706b6b6824639c51601c8d1e615276b372db1640d1743640c

--- a/third_party/rake-compiler-dock/rake_aarch64-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_aarch64-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-aarch64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.1-mri-aarch64-linux
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_arm64-darwin.current_version
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin:70299f6e5c476d95cee09619e913517f8617c184@sha256:89870a9e90d287966e721dbe690ee3135e43d01f14bd009d176b591f9b7ed758
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin:86fc09040ce57a5eef734ac1253b04fdc794db2c@sha256:c59fd7fdf5f4e14c472818bb50f7ccc6e7036e594910e0f4364bd0459e2f0263

--- a/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_arm64-darwin/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-arm64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.1-mri-arm64-darwin

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt:094652c0bd5f3ad871de94751c52f0f659b70750@sha256:c4f9c4bfbf356ca14b01467b8dcd61212ab3aa2406c02ff66926fdac331f5c61
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt:54e9b4740bc04564d860e4d7eac7b134013585ff@sha256:0908faeecd55d23fd547b320b740c9726bb6a03d6896423327f0ef0d04bc1326

--- a/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw-ucrt/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x64-mingw-ucrt
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.1-mri-x64-mingw-ucrt
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x64-mingw32.current_version
+++ b/third_party/rake-compiler-dock/rake_x64-mingw32.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32:5f93062e5d17d1e07274f8eec86e75c5885502d5@sha256:51dcb0a8ccb5dd235346fde7946ee8f9d9ffbb878c4bb1e47b30a5c92bc24993
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32:a016ec4c413aee83e86534ebb8b68e244e4544b1@sha256:e4b65bba3ff2d430e334ef61658437770113ac74a4d2b95da56e5286e10bd452

--- a/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x64-mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x64-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.1-mri-x64-mingw32
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x86-linux.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-linux.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux:bf82f52fc5be975a451ba77d024a020f56f1ca8f@sha256:1674b52914988c4c200925081a4ab42656330f6f5016f6c6304c48e9f15b15fa
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux:d03b95e11512fc2b26a23856abd6d6c2577badf7@sha256:dbd0492d14085db23246ee1b163e4afcb2dfd66f8584e75cfac64438550f4af7

--- a/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.1-mri-x86-linux
 
 #=================
 # Install ccache

--- a/third_party/rake-compiler-dock/rake_x86-mingw32.current_version
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32:6e984ecb86ac2933f67c1eea127099134a28358b@sha256:01a9c8b5d394051326e26ccf59b2e9fc56766e42863d651d592f5ddb52067337
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32:0bd762bdf0f1d5fa314a1e9fb625c1db1d8c8df1@sha256:08eb657745f940556b17a55af44e314ec4e6f0d886910a22edd0e6729d2d3025

--- a/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86-mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86-mingw32
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.1-mri-x86-mingw32
 
 RUN find / -name win32.h | while read f ; do sed -i 's/gettimeofday/rb_gettimeofday/' $f ; done
 

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin:9a3f30d675fc628fc38502e2dbf6f505cd0fbd7d@sha256:b40deee2128bae743dcc705379b81119f7910ee0452e9ed739d8974ca2941ff0
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin:bb7d60972542eb490ca09b1ec821c39111887785@sha256:98084189b43ed5164a634b713f326fdc46d43bf3257dcc41d2f753acd2e7f5d7

--- a/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-darwin/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86_64-darwin
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.1-mri-x86_64-darwin

--- a/third_party/rake-compiler-dock/rake_x86_64-linux.current_version
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux.current_version
@@ -1,1 +1,1 @@
-us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux:e05348c1a030ebfbb062363d1b3a192f4176c7b5@sha256:19211a7f61889f4996bf4722baf85c5d6197aa85819cc0c914d5f37e638abddf
+us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux:e72abb8aa3dbc8aa679dfce3287983b5ef09fc96@sha256:8c9439ddff245b262233ae3298540b7fd7440b69b5d072cf5a3a8a8ea0efa89b

--- a/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
+++ b/third_party/rake-compiler-dock/rake_x86_64-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.0-mri-x86_64-linux
+FROM ghcr.io/rake-compiler/rake-compiler-dock-image:1.7.1-mri-x86_64-linux
 
 #=================
 # Install ccache

--- a/tools/bazelify_tests/dockerimage_current_versions.bzl
+++ b/tools/bazelify_tests/dockerimage_current_versions.bzl
@@ -19,14 +19,14 @@ accessible to bazel builds.
 """
 
 DOCKERIMAGE_CURRENT_VERSIONS = {
-    "third_party/rake-compiler-dock/rake_aarch64-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux@sha256:cff514568925140423831235a0248c97cc96c9aa2e8d4363691ca78943b03582",
-    "third_party/rake-compiler-dock/rake_arm64-darwin.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin@sha256:89870a9e90d287966e721dbe690ee3135e43d01f14bd009d176b591f9b7ed758",
-    "third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt@sha256:c4f9c4bfbf356ca14b01467b8dcd61212ab3aa2406c02ff66926fdac331f5c61",
-    "third_party/rake-compiler-dock/rake_x64-mingw32.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32@sha256:51dcb0a8ccb5dd235346fde7946ee8f9d9ffbb878c4bb1e47b30a5c92bc24993",
-    "third_party/rake-compiler-dock/rake_x86-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux@sha256:1674b52914988c4c200925081a4ab42656330f6f5016f6c6304c48e9f15b15fa",
-    "third_party/rake-compiler-dock/rake_x86-mingw32.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32@sha256:01a9c8b5d394051326e26ccf59b2e9fc56766e42863d651d592f5ddb52067337",
-    "third_party/rake-compiler-dock/rake_x86_64-darwin.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin@sha256:b40deee2128bae743dcc705379b81119f7910ee0452e9ed739d8974ca2941ff0",
-    "third_party/rake-compiler-dock/rake_x86_64-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux@sha256:19211a7f61889f4996bf4722baf85c5d6197aa85819cc0c914d5f37e638abddf",
+    "third_party/rake-compiler-dock/rake_aarch64-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_aarch64-linux@sha256:6386d6af4126662706b6b6824639c51601c8d1e615276b372db1640d1743640c",
+    "third_party/rake-compiler-dock/rake_arm64-darwin.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_arm64-darwin@sha256:c59fd7fdf5f4e14c472818bb50f7ccc6e7036e594910e0f4364bd0459e2f0263",
+    "third_party/rake-compiler-dock/rake_x64-mingw-ucrt.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw-ucrt@sha256:0908faeecd55d23fd547b320b740c9726bb6a03d6896423327f0ef0d04bc1326",
+    "third_party/rake-compiler-dock/rake_x64-mingw32.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x64-mingw32@sha256:e4b65bba3ff2d430e334ef61658437770113ac74a4d2b95da56e5286e10bd452",
+    "third_party/rake-compiler-dock/rake_x86-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-linux@sha256:dbd0492d14085db23246ee1b163e4afcb2dfd66f8584e75cfac64438550f4af7",
+    "third_party/rake-compiler-dock/rake_x86-mingw32.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86-mingw32@sha256:08eb657745f940556b17a55af44e314ec4e6f0d886910a22edd0e6729d2d3025",
+    "third_party/rake-compiler-dock/rake_x86_64-darwin.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-darwin@sha256:98084189b43ed5164a634b713f326fdc46d43bf3257dcc41d2f753acd2e7f5d7",
+    "third_party/rake-compiler-dock/rake_x86_64-linux.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/rake_x86_64-linux@sha256:8c9439ddff245b262233ae3298540b7fd7440b69b5d072cf5a3a8a8ea0efa89b",
     "tools/dockerfile/distribtest/cpp_debian11_aarch64_cross_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cpp_debian11_aarch64_cross_x64@sha256:97ff55660fb93f4b31c029f2935bd18edf82e55d4df65376e55ed97b228a49c7",
     "tools/dockerfile/distribtest/cpp_debian11_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/cpp_debian11_x64@sha256:beb3a8bedc067f4c8f54c8efe31f3d7149056c39c9751aaa395c788dd54e0a7e",
     "tools/dockerfile/distribtest/csharp_alpine_x64.current_version": "docker://us-docker.pkg.dev/grpc-testing/testing-images-public/csharp_alpine_x64@sha256:65083a6c7b1e6f18374ac6218a924409dfc6ab526ec627b9a33d81e21c93e025",


### PR DESCRIPTION
As per https://github.com/grpc/grpc/pull/38338#issuecomment-2569465575

I went ahead and uploaded images, so this updates versions again. 

